### PR TITLE
simple fix of /getRank and /setRank admin commands

### DIFF
--- a/sku.0/sys.server/compiled/game/script/library/gm.java
+++ b/sku.0/sys.server/compiled/game/script/library/gm.java
@@ -70,7 +70,9 @@ public class gm extends script.base_script
     {
         "Select Roadmap",
         "Earn Current Skill",
-        "Set Roadmap Progression"
+        "Set Roadmap Progression",
+		"Grant Master Politician",
+		"Grant Master Chronicler"
     };
     public static String removeKeyword(String params, String keyword) throws InterruptedException
     {

--- a/sku.0/sys.server/compiled/game/script/player/player_utility.java
+++ b/sku.0/sys.server/compiled/game/script/player/player_utility.java
@@ -1317,7 +1317,32 @@ public class player_utility extends script.base_script
             case 2:
             String template = getSkillTemplate(target);
             gmGrantSkillRoadmapProgression(self, target, template);
-            break;
+			break;
+			case 3:
+				skill.grantAllPoliticianSkills(target);
+				sendSystemMessageTestingOnly(self, getPlayerName(target)+" was successfully granted all Politician skills.");
+			break;
+			case 4:
+				skill.grantSkill(target, "class_chronicles_novice");
+				skill.grantSkill(target, "class_chronicles_1");
+				skill.grantSkill(target, "class_chronicles_2");
+				skill.grantSkill(target, "class_chronicles_3");
+				skill.grantSkill(target, "class_chronicles_4");
+				skill.grantSkill(target, "class_chronicles_5");
+				skill.grantSkill(target, "class_chronicles_6");
+				skill.grantSkill(target, "class_chronicles_7");
+				skill.grantSkill(target, "class_chronicles_8");
+				skill.grantSkill(target, "class_chronicles_9");
+				skill.grantSkill(target, "class_chronicles_10");
+				skill.grantSkill(target, "class_chronicles_11");
+				skill.grantSkill(target, "class_chronicles_12");
+				skill.grantSkill(target, "class_chronicles_13");
+				skill.grantSkill(target, "class_chronicles_14");
+				skill.grantSkill(target, "class_chronicles_15");
+				skill.grantSkill(target, "class_chronicles_16");
+				skill.grantSkill(target, "class_chronicles_master");
+				sendSystemMessageTestingOnly(self, getPlayerName(target)+" was successfully granted all Chronicler skills.");
+			break;
             default:
             utils.removeScriptVarTree(self, "gmGrantSkill");
             return SCRIPT_CONTINUE;


### PR DESCRIPTION
These commands were written prior to the Chapter 3 update that restructured ranks which is why they reference 15 ranks and a string file that doesn't contain rank names anymore (and also why the method called doesn't work). So, this fixes that.

Notably, this is more of a quick and dirty fix to get them working more than the "best possible" solution, but because it's an admin script that would only be rarely used by GMs, I don't really see it as much of a problem; however, I more than encourage anyone else to make it better. I just needed it fixed on our server and figured I'd share the wealth. xoxo 