### PR TITLE
Junk Dealer Lucky Proc

### DIFF
--- a/sku.0/sys.server/compiled/game/script/library/smuggler.java
+++ b/sku.0/sys.server/compiled/game/script/library/smuggler.java
@@ -306,9 +306,6 @@ public class smuggler extends script.base_script
         if (price > 0 && !hasObjVar(item, "quest_item"))
         {
             dictionary params = new dictionary();
-            params.put("item", item);
-            params.put("price", price);
-            params.put("reshowSui", reshowSui);
             if (luck.isLucky(player, 0.01f))
             {
                 float bonus = price * 0.2f;
@@ -318,6 +315,9 @@ public class smuggler extends script.base_script
                 }
                 price += bonus;
             }
+            params.put("item", item);
+            params.put("price", price);
+            params.put("reshowSui", reshowSui);
             if (fence)
             {
                 blog("smuggler.sellJunkItem() this is a fence player");


### PR DESCRIPTION
This fixes a credit exploit. If you have an item which sells for a large amount to the Junk Dealer, you can spam sell/buy-back. The Lucky-proc sell price is not taken in to account when buying the item back. If you sell an item for 50mil, and proc Lucky, it sells for 60mil - a profit of 10mil. Buying it back only costs you 50mil. Rinse and repeat.