### PR TITLE
Updates NPC vendor mobiles to use vendor inventory (not player housing vendors)

### DIFF
--- a/sku.0/sys.server/compiled/game/object/mobile/dressed_wod_sm_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/dressed_wod_sm_vendor.tpf
@@ -9,3 +9,10 @@
 
 sharedTemplate = "object/mobile/shared_dressed_wod_sm_vendor.iff"
 
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/halloween_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/halloween_vendor.tpf
@@ -10,3 +10,10 @@ nameGeneratorType = "human"
 
 sharedTemplate = "object/mobile/shared_halloween_vendor.iff"
 
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/imperial_emperorsday_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/imperial_emperorsday_vendor.tpf
@@ -13,3 +13,11 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_imperial_emperorsday_vendor.iff"
+
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/life_day_imperial_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/life_day_imperial_vendor.tpf
@@ -13,3 +13,11 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_life_day_imperial_vendor.iff"
+
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/life_day_rebel_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/life_day_rebel_vendor.tpf
@@ -13,3 +13,11 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_life_day_rebel_vendor.iff"
+
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/lifeday_wookiee_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/lifeday_wookiee_vendor.tpf
@@ -13,3 +13,11 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_lifeday_wookiee_vendor.iff"
+
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/nova_orion_vendor_nova.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/nova_orion_vendor_nova.tpf
@@ -13,3 +13,11 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_nova_orion_vendor_nova.iff"
+
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/nova_orion_vendor_orion.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/nova_orion_vendor_orion.tpf
@@ -13,3 +13,11 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_nova_orion_vendor_orion.iff"
+
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/npc_dressed_wod_ns_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/npc_dressed_wod_ns_vendor.tpf
@@ -9,3 +9,10 @@
 
 sharedTemplate = "object/mobile/shared_npc_dressed_wod_ns_vendor.iff"
 
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]

--- a/sku.0/sys.server/compiled/game/object/mobile/rebel_emperorsday_vendor.tpf
+++ b/sku.0/sys.server/compiled/game/object/mobile/rebel_emperorsday_vendor.tpf
@@ -13,3 +13,10 @@
 @class object_template 0
 
 sharedTemplate = "object/mobile/shared_rebel_emperorsday_vendor.iff"
+contents = [
+					[slotName = "inventory",
+					equipObject = true,
+					content = "object/tangible/inventory/vendor_inventory.iff"],
+					[slotName = "mission_bag",
+					equipObject = true,
+					content = "object/tangible/mission_bag/mission_bag.iff"]]


### PR DESCRIPTION
This updates unique NPC vendors found in the world to use vendor_inventory's instead of the default creature_inventory. This follows SOE's use for the Aurilia vendors, allowing for a greater item capacity (unlimited). Previously they utilized the creature_inventory which had a capacity of 75 but in practice was closer to 37 items. Only mobiles that were exclusively used as world vendors were updated. Some vendors such as Hoth, Loveday and Meatlumps it may be advised to give them unique mobiles in order to update them to this. This is purely serverside and does not need an update to the client.