### PR TITLE
NPC Vendor Permissions Fix

### DIFF
--- a/sku.0/sys.server/compiled/game/script/npc/vendor/vendor.java
+++ b/sku.0/sys.server/compiled/game/script/npc/vendor/vendor.java
@@ -101,6 +101,13 @@ public class vendor extends script.base_script
                         {
                             objectForSale = createObjectOverloaded(item, containerList[idx]);
                         }
+                        
+			            if(hasObjVar(objectForSale, "noTrade"))
+			            {
+				            removeObjVar(objectForSale, "noTrade");
+				            attachScript(objectForSale, "item.special.nomove");
+			            }                        
+                        
                         setObjVar(objectForSale, OBJECT_FOR_SALE_CASH_COST, creditCost);
                         setObjVar(objectForSale, OBJECT_FOR_SALE_TOKEN_COST, tokenCost);
                         if (hasObjVar(self, VENDOR_TOKEN_TYPE))

--- a/sku.0/sys.server/compiled/game/script/terminal/terminal_character_builder.java
+++ b/sku.0/sys.server/compiled/game/script/terminal/terminal_character_builder.java
@@ -108,7 +108,8 @@ public class terminal_character_builder extends script.base_script
         "Heroic Box of Achievements",
         "Tusken, Axkva Min, Echo Base, IG-88 Tokens",
         "Exar Kun, Black Sun, Marauder, Space Duty Tokens",
-        "Holoshrouds for costume testing"
+        "Holoshrouds for costume testing",
+	"Chronicles Tokens"
     };
     public static final String[] RESOURCE_TYPES = {
         "Creature Resources",
@@ -5276,7 +5277,7 @@ public class terminal_character_builder extends script.base_script
             closeOldWindow(player);
             return SCRIPT_CONTINUE;
         }
-        if (idx == -1 || idx > WEAPON_OPTIONS.length)
+        if (idx == -1 || idx > DEV_TESTING_OPTIONS.length)
         {
             cleanScriptVars(player);
             return SCRIPT_CONTINUE;
@@ -5327,6 +5328,11 @@ public class terminal_character_builder extends script.base_script
                 static_item.createNewItemFunction("item_costume_kit_holiday", pInv, 25);
                 static_item.createNewItemFunction("item_costume_kit", pInv, 25);
                 break;
+            case 10:
+                static_item.createNewItemFunction("item_pgc_token_01", pInv, 250);
+                static_item.createNewItemFunction("item_pgc_token_02", pInv, 250);
+                static_item.createNewItemFunction("item_pgc_token_03", pInv, 250);
+                break;		
                 default:
                 cleanScriptVars(player);
                 break;


### PR DESCRIPTION
Simple fix provided by Aconite to correct a permission issue with no-trade items on NPC Vendors and addition of Chroniclers Tokens to the frog.