### PR TITLE
Make Structures Tradeable Again

### DIFF
--- a/sku.0/sys.server/compiled/game/script/library/utils.java
+++ b/sku.0/sys.server/compiled/game/script/library/utils.java
@@ -5914,6 +5914,9 @@ public class utils extends script.base_script
                     if (novendor && hasScript(item, "terminal.vendor")) {
                         continue;
                     }
+                    if (hasScript(item, "terminal.terminal_structure")){
+                        continue;
+                    }
                     if (!canTrade(item)) {
                         return item;
                     } else if (utils.isContainer(item)) {


### PR DESCRIPTION
Simple fix in utils.java to exclude structure terminals from the NoTrade item check.