### PR TITLE
TPF Typo Fixes

### DIFF
--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bicep_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bicep_l.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_left_bicep.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_left_bicep.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bicep_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bicep_r.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_right_bicep.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_right_bicep.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_boots.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_boots.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_boots.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_boots.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bracer_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bracer_l.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_left_bracer.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_left_bracer.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bracer_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_bracer_r.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_right_bracer.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_right_bracer.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_chest_plate.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_chest_plate.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_chest_plate.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_chest_plate.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_belt.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_belt.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_belt.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_hunter_belt.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bicep_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bicep_l.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_left_bicep.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_left_bicep.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bicep_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bicep_r.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_right_bicep.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_right_bicep.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_boots.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_boots.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_boots.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_boots.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bracer_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bracer_l.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_left_bracer.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_left_bracer.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bracer_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_bracer_r.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_right_bracer.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_right_bracer.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_chest_plate.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_chest_plate.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_chest_plate.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_chest_plate.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_gloves.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_gloves.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_gloves.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_helmet.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_helmet.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_helmet.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_leggings.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_crafted_leggings.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_leggings.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_leggings.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_gloves.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_gloves.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_gloves.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_helmet.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_helmet.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_helmet.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_leggings.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/bounty_hunter/armor_bounty_hunter_leggings.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_leggings.iff"
+armor = "abstract/armor_statistics/armor/bounty_hunter/base/statistics_armor_bounty_hunter_leggings.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s01_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s01_gloves.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_chest_gloves.iff"
+armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_gloves.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s01_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s01_helmet.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_chest_helmet.iff"
+armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_helmet.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s02_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s02_gloves.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_chest_gloves.iff"
+armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_gloves.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s02_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s02_helmet.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_chest_helmet.iff"
+armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_helmet.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s03_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s03_gloves.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_chest_gloves.iff"
+armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_gloves.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s03_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/marauder/armor_marauder_s03_helmet.tpf
@@ -3,7 +3,7 @@
 
 @class tangible_object_template 3
 
-armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_chest_helmet.iff"
+armor = "abstract/armor_statistics/armor/marauder/base/statistics_armor_marauder_helmet.iff"
 
 @class object_template 2
 

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_belt.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_belt.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_belt.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bicep_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bicep_l.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_bicep_l.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bicep_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bicep_r.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_bicep_r.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_boots.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_boots.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_boots.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bracer_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bracer_l.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_bracer_l.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bracer_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_bracer_r.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_bracer_r.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_chest_plate.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_chest_plate.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_chest_plate.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_gloves.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_gloves.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_helmet.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_helmet.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_leggings.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/rebel_snow/armor_rebel_snow_leggings.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/rebel_snow/shared_armor_rebel_snow_leggings.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Rebel", "item.set_id" = 100001]
+objvars = +["faction_recruiter.faction"="Rebel", "item.set.set_id" = 100001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_belt.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_belt.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_belt.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bicep_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bicep_l.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_bicep_l.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bicep_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bicep_r.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_bicep_r.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_boots.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_boots.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_boots.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bracer_l.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bracer_l.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_bracer_l.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bracer_r.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_bracer_r.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_bracer_r.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_chest_plate.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_chest_plate.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_chest_plate.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_gloves.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_gloves.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_gloves.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_helmet.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_helmet.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_helmet.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]

--- a/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_leggings.tpf
+++ b/sku.0/sys.server/compiled/game/object/tangible/wearables/armor/snowtrooper/armor_snowtrooper_leggings.tpf
@@ -10,4 +10,4 @@ armor = ""
 sharedTemplate = "object/tangible/wearables/armor/snowtrooper/shared_armor_snowtrooper_leggings.iff"
 
 scripts = +["npc.faction_recruiter.faction_item", "item.buff_worn_item", "item.set_bonus_item"]
-objvars = +["faction_recruiter.faction"="Imperial", "item.set_id" = 110001]
+objvars = +["faction_recruiter.faction"="Imperial", "item.set.set_id" = 110001]


### PR DESCRIPTION
Rebel and Imp Hoth Armor: Fixed typos that cause the set bonuses to not apply to re-crafted armor.
Bounty Hunter Armor: Fixed typos that throw console errors.
Marauder Armor: Fixed typos that throw console errors.