### PR TITLE
NoTrade Removable Fix

### DIFF
--- a/sku.0/sys.server/compiled/game/script/item/special/no_trade_removable.java
+++ b/sku.0/sys.server/compiled/game/script/item/special/no_trade_removable.java
@@ -25,6 +25,7 @@ public class no_trade_removable extends script.base_script {
     public static final string_id SID_ITEM_MADE_TRADABLE = new string_id("system_msg", "item_made_tradable");
     
     public static final String SCRIPT_NAME = "item.special.no_trade_removable";
+    public static final String NO_TRADE_SCRIPT_NAME = "item.special.nomove";
 
     public int OnObjectMenuRequest(obj_id self, obj_id player, menu_info mi) throws InterruptedException {
         if ((getOwner(self) == player || isGod(player)) && hasObjVar(self, "noTrade")
@@ -48,6 +49,9 @@ public class no_trade_removable extends script.base_script {
 
             if (hasObjVar(self, "noTrade")) {
                 removeObjVar(self, "noTrade");
+                if (hasScript(self, NO_TRADE_SCRIPT_NAME)) {
+                    detachScript(self, NO_TRADE_SCRIPT_NAME);
+                }
                 sendSystemMessage(player, SID_ITEM_MADE_TRADABLE);
                 CustomerServiceLog("noTrade", getPlayerName(player) + " (" + player + ") removed the noTrade ObjVar from object " + getTemplateName(self) + " (" + self + ")");
                 detachScript(self, SCRIPT_NAME);

--- a/sku.0/sys.server/compiled/game/script/library/static_item.java
+++ b/sku.0/sys.server/compiled/game/script/library/static_item.java
@@ -152,6 +152,12 @@ public class static_item extends script.base_script
             }
         }
         attachScript(object, "item.static_item_base");
+        // attaching the no_trade_removable script. 
+        // Doing this here instead of the above because this runs on Init for all existing static_items instead of only at creation time
+        String[] no_trade_removable_items = dataTableGetStringColumn(ITEM_NO_TRADE_REMOVABLE_TABLE, 0);
+        if(no_trade_removable_items != null && Arrays.asList(no_trade_removable_items).contains(itemName)) {
+            attachScript(object, "item.special.no_trade_removable");
+        }
         if (!jedi.isCrystalTuned(object))
         {
             setName(object, "");

--- a/sku.0/sys.shared/compiled/game/object/draft_schematic/space/chassis/shared_havoc.tpf
+++ b/sku.0/sys.shared/compiled/game/object/draft_schematic/space/chassis/shared_havoc.tpf
@@ -13,7 +13,7 @@ attributes = [
 	[name = "crafting" "complexity", experiment = "" "", value = 31..31],
 	[name = "crafting" "xp", experiment = "" "", value = 20000..20000],
 	[name = "crafting" "hp", experiment = "crafting" "exp_hp", value = 1350..2350],
-	[name = "crafting" "massMax", experiment = "crafting" "exp_massMax", value = 55375..58625]]
+	[name = "crafting" "massMax", experiment = "crafting" "exp_massMax", value = 160000..184000]]
 
 slots = [
 	[name = "craft_item_ingredients_n" "frame", hardpoint = ""],


### PR DESCRIPTION
1. Added the function to remove the noTrade script from items along with the objvar in cases where someone may add an item to no_trade_removable.tab that has the script attached.

2. No Trade Removable items have been getting Marked as NoTradeRemovable, but the script hasn't been getting attached to those items. Added this to item initialization where the static_item_base script is already being attached.