### PR TITLE
Added a config parameter to enable ITV in a city

### DIFF
--- a/sku.0/sys.server/compiled/game/script/player/player_travel.java
+++ b/sku.0/sys.server/compiled/game/script/player/player_travel.java
@@ -1107,18 +1107,24 @@ public class player_travel extends script.base_script
             buff.removeBuff(player, ITV_PICKUP_BUFF);
             return false;
         }
+
         location here = getLocation(player);
-        if (locations.isInCity(here))
-        {
-            sendSystemMessage(player, SID_NO_PICKUP_IN_TOWN);
-            return false;
-        }
-        region geoCities[] = getRegionsWithGeographicalAtPoint(here, regions.GEO_CITY);
-        if (geoCities != null && geoCities.length > 0)
-        {
-            sendSystemMessage(player, SID_INVALID_PICKUP_LOC);
-            return false;
-        }
+		
+		boolean allowInstantTravelInCity = utils.checkConfigFlag("GameServer", "allowInstantTravelInCity");
+
+
+		if (!allowInstantTravelInCity && locations.isInCity(here))
+		{
+			 return false;
+		}
+		 
+		region geoCities[] = getRegionsWithGeographicalAtPoint(here, regions.GEO_CITY);
+		if (!allowInstantTravelInCity && geoCities != null && geoCities.length > 0)
+		{
+			return false;
+		}
+
+
         region[] regionList = getRegionsWithPvPAtPoint(here, regions.PVP_REGION_TYPE_ADVANCED);
         if (regionList != null && regionList.length > 0)
         {


### PR DESCRIPTION
Added a configuration parameter that allows ITVs to be used in cities.

Kashyyyk and adventure planets are still exempt from ITV usage. The default is off, preserving vanilla behavior.

Example config to enable city ITV usage:

[GameServer]
allowInstantTravelInCity=true
