### PR TITLE
Fix Power Hammer appearanceBonus_max_high value

### DIFF
--- a/sku.0/sys.server/compiled/game/datatables/crafting/weapon_appearance.tab
+++ b/sku.0/sys.server/compiled/game/datatables/crafting/weapon_appearance.tab
@@ -230,7 +230,7 @@ slot																																		resource	0	grip	petrochem_inert	7
 slot																																		template	0	vibration_generator	object/tangible/component/weapon/vibro_unit_base.iff	1																												
 slot																																		template	0	power_circuits	object/tangible/component/item/electronic_control_unit.iff	1																												
 slot																																		template	0	weapon_core	object/tangible/component/weapon/core/weapon_core_melee_base.iff	1																												
-weapon	melee	weapon_appearance_maul		systems.crafting.weapon.core.crafting_new_weapon_final	25	weapon	5	weapon_crafting		object/weapon/melee/2h_sword/2h_sword_maul.iff	object/weapon/melee/2h_sword/2h_sword_maul.iff	40	120	800	1100	0	0	0	0	0	0	kinetic	none	-1	-1	melee	melee	1	1	100	100		5							sys.server/compiled/game/object/draft_schematic/weapon/appearance/																							0	42	0	20
+weapon	melee	weapon_appearance_maul		systems.crafting.weapon.core.crafting_new_weapon_final	25	weapon	5	weapon_crafting		object/weapon/melee/2h_sword/2h_sword_maul.iff	object/weapon/melee/2h_sword/2h_sword_maul.iff	40	120	800	1100	0	0	0	0	0	0	kinetic	none	-1	-1	melee	melee	1	1	100	100		5							sys.server/compiled/game/object/draft_schematic/weapon/appearance/																							0	42	0	30
 slot																																		resource	0	grip_unit	metal	40																												
 slot																																		resource	0	reactive_striking_surface	iron_kammris	75																												
 slot																																		resource	0	power_cell_brackets	copper	24																												


### PR DESCRIPTION
## Summary

The `weapon_appearance_maul` (Power Hammer) entry in `weapon_appearance.tab` had `appearanceBonus_max_high` set to `20`, which is inconsistent with comparable two-handed melee weapons in the same table.

- `weapon_appearance_maul`: was `20`, corrected to `30`
- `weapon_appearance_quest_maul` (quest variant): uses `40`
- Other 2H weapons: use `30`

The `appearanceBonus_max_high` column controls the upper bound of the appearance bonus range shown during crafting. A value of `20` means the Power Hammer could never roll a bonus higher than 20, placing it far below the tier it occupies compared to its counterparts.

Fixes #340