### PR TITLE
Fix RLS crates not dropping for grouped players

### DIFF
--- a/sku.0/sys.server/compiled/game/script/library/loot.java
+++ b/sku.0/sys.server/compiled/game/script/library/loot.java
@@ -2491,6 +2491,14 @@ public class loot extends script.base_script
         // get the attacker who did the most damage.
         obj_id player = getObjIdObjVar(target, xp.VAR_TOP_GROUP);
 
+        // VAR_TOP_GROUP stores a group object when the top damage dealer is grouped.
+        // Pick a random member of that group to receive the RLS chest.
+        if (group.isGroupObject(player)) {
+            obj_id[] members = utils.getLocalGroupMemberIds(player);
+            if (members == null || members.length == 0) return false;
+            player = members[rand(0, members.length - 1)];
+        }
+
         // make sure the attacker is a player.
         if(!isValidId(player) || !isPlayer(player)){
             return false;


### PR DESCRIPTION
## Summary

Rare Loot System (RLS) chests never dropped for grouped players. Solo play was unaffected.

**Root cause:**

`xp.VAR_TOP_GROUP` stores a **group object** ID when the top damage dealer is part of a group (see `xp.java` line 824-836). In `loot.addRareLoot()`, this value is treated as the player recipient and immediately fails the `isPlayer()` check, returning `false` before any roll is made.

**Fix:**

Detect when `VAR_TOP_GROUP` holds a group object and resolve it to a random group member. This matches how other group loot mechanics are handled throughout the codebase (e.g., `chooseRandomLootPlayerFromGroup`).

Fixes #343