### PR TITLE
Fix Medium Generic Windowed House Style 3 not deploying

### DIFF
--- a/sku.0/sys.shared/compiled/game/object/building/player/shared_player_house_generic_medium_windowed_s03.tpf
+++ b/sku.0/sys.shared/compiled/game/object/building/player/shared_player_house_generic_medium_windowed_s03.tpf
@@ -16,6 +16,8 @@ clearFloraRadius = 38
 objectName = "building_name" "player_house_generic_medium_windowed_s03"
 detailedDescription = "building_detail" "player_house_generic_medium_windowed_s03"
 
+appearanceFilename = "appearance/ply_house_med_s03_hue_r0_exterior.apt"
+
 portalLayoutFilename = "appearance/ply_house_med_s03_hue.pob"
 
 clientDataFile = "clientdata/building/shared_player_house_tatooine_medium_style_01.cdf"


### PR DESCRIPTION
## Summary

The Medium Generic Windowed House Style 3 deed did nothing when used from the radial menu.

**Root cause:**

`shared_player_house_generic_medium_windowed_s03.tpf` was missing the `appearanceFilename` field. The s01 variant uses `appearance/ply_all_house_m_window_s01_hue_r0_exterior.apt` and the s02 uses `appearance/ply_all_house_m_window_s02_hue_r0_exterior.apt`. The structure placement HUD uses this file to render the exterior preview when a player clicks "Use Deed". Without it, placement fails silently.

**Fix:**

Added `appearanceFilename` following the naming convention of the s03 portal layout (`ply_house_med_s03_hue.pob` → `ply_house_med_s03_hue_r0_exterior.apt`).

> **Note:** If the exact filename of the client-side `.apt` differs, please adjust accordingly — the key fix is that this field must be present for deed placement to work.

Fixes #276