### PR TITLE
fix: install zlib1g before running DataTableTool in CI

### DIFF
--- a/.github/workflows/ant-compile-tab.yml
+++ b/.github/workflows/ant-compile-tab.yml
@@ -23,7 +23,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup System Requisites
-        run: sudo chmod 777 ${GITHUB_WORKSPACE}/include/DataTableTool
+        run: |
+          sudo apt-get install -y zlib1g
+          sudo chmod 777 ${GITHUB_WORKSPACE}/include/DataTableTool
 
       # NOTE: DataTableTool was built and placed in dsrc/include which is called by ant when compile_tab is ran
       # The DataTableTool in dsrc is a special version modified specifically to work with the GitHub Runner so DO NOT replace it with a regular build


### PR DESCRIPTION
## Summary

Every pull request that touches `.tab` files is currently failing CI with:

```
DataTableTool: error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory
build.xml:118: apply returned: 127
```

The `ubuntu-latest` runner upgraded to Ubuntu 24.04, which does not include `zlib1g` by default. The `DataTableTool` binary links against `libz.so.1` and crashes immediately without it.

The fix is a single `apt-get install -y zlib1g` added to the Setup System Requisites step before `ant` is invoked.

## Test plan

- [ ] Verify any tab-file PR passes the `Build Data Tables` CI check after this merges