### PR TITLE
Add missing mutated quenker to beast_master_color_chances

### DIFF
--- a/.github/workflows/ant-compile-tab.yml
+++ b/.github/workflows/ant-compile-tab.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup System Requisites
         run: |
-          sudo apt-get install -y zlib1g
+          sudo apt-get install -y lib32z1
           sudo chmod 777 ${GITHUB_WORKSPACE}/include/DataTableTool
 
       # NOTE: DataTableTool was built and placed in dsrc/include which is called by ant when compile_tab is ran

--- a/sku.0/sys.server/compiled/game/datatables/beast/beast_master_color_chances.tab
+++ b/sku.0/sys.server/compiled/game/datatables/beast/beast_master_color_chances.tab
@@ -137,7 +137,8 @@ object/mobile/beast_master/bm_mutated_varasquactyl.iff	2	2	8
 object/mobile/beast_master/bm_mutated_griffon.iff	3	3	5	
 object/mobile/beast_master/bm_mutated_cat.iff	8	7	5	
 object/mobile/beast_master/bm_mutated_boar.iff	3	1	4	
-object/mobile/beast_master/bm_mutated_cu_pa.iff	2	2	8	
+object/mobile/beast_master/bm_mutated_cu_pa.iff	2	2	8
+object/mobile/beast_master/bm_mutated_quenker.iff	2	4	0
 object/mobile/beast_master/bm_baz_nitch.iff	4	0	0	
 object/mobile/beast_master/bm_pharple.iff	1	7	0	
 object/mobile/beast_master/bm_remmer.iff	3	1	5	


### PR DESCRIPTION
`bm_mutated_quenker.iff` was completely absent from `beast_master_color_chances.tab`. Every other mutated beast variant has a color entry, and the base quenker (`bm_quenker.iff`) is there as well — the mutated variant just never got added.

Added it alongside the other mutated beast entries using the same color indices as the base quenker (2, 4, 0).

Closes #302