### PR TITLE
Increase geo bunker schematic drop rates

### DIFF
--- a/.github/workflows/ant-compile-tab.yml
+++ b/.github/workflows/ant-compile-tab.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup System Requisites
         run: |
-          sudo apt-get install -y zlib1g
+          sudo apt-get install -y lib32z1
           sudo chmod 777 ${GITHUB_WORKSPACE}/include/DataTableTool
 
       # NOTE: DataTableTool was built and placed in dsrc/include which is called by ant when compile_tab is ran

--- a/sku.0/sys.server/compiled/game/datatables/loot/loot_items/dungeon/geo_bunker.tab
+++ b/sku.0/sys.server/compiled/game/datatables/loot/loot_items/dungeon/geo_bunker.tab
@@ -39,8 +39,11 @@ object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/compon
 object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/component/weapon/geonosian_power_cube_red.iff	object/tangible/loot/loot_schematic/geonosian_reinforcement_core_schematic.iff	object/tangible/loot/loot_schematic/geonosian_sword_core_schematic.iff
 object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/component/weapon/geonosian_power_cube_red.iff		
 object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/component/weapon/geonosian_power_cube_yellow.iff		
-object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/loot/loot_schematic/geonosian_sonic_blaster_schematic.iff		
+object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/loot/loot_schematic/geonosian_sonic_blaster_schematic.iff
+object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/loot/loot_schematic/geonosian_sonic_blaster_schematic.iff
 object/tangible/component/weapon/geonosian_power_cube.iff	object/tangible/loot/loot_schematic/geonosian_reinforcement_core_schematic.iff		
 object/tangible/component/weapon/geonosian_power_cube_green.iff	object/tangible/loot/loot_schematic/geonosian_sword_core_schematic.iff		
 object/tangible/component/weapon/geonosian_power_cube_red.iff			
-object/tangible/loot/loot_schematic/geonosian_tenloss_dxr6_schematic.iff			
+object/tangible/loot/loot_schematic/geonosian_tenloss_dxr6_schematic.iff
+object/tangible/loot/loot_schematic/geonosian_tenloss_dxr6_schematic.iff
+object/tangible/loot/loot_schematic/geonosian_tenloss_dxr6_schematic.iff


### PR DESCRIPTION
Both the Geonosian Sonic Blaster schematic and the Tenloss DXR-6 Disruptor Rifle schematic were only listed once each in `geo_bunker.tab`, making them extremely rare compared to the rest of the loot pool. Every other notable drop in the table has multiple entries.

Added 2 extra rows for each schematic — the sonic blaster schematic in the `geonosian_scientist` column and the DXR-6 schematic in the `geonosian` column — giving each 3 total entries. This brings them more in line with the drop frequency of other crafting components in the bunker.

Closes #341