### PR TITLE
Fix DataTableTool CI: install lib32z1 not zlib1g

### DIFF
--- a/.github/workflows/ant-compile-tab.yml
+++ b/.github/workflows/ant-compile-tab.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup System Requisites
         run: |
-          sudo apt-get install -y zlib1g
+          sudo apt-get install -y lib32z1
           sudo chmod 777 ${GITHUB_WORKSPACE}/include/DataTableTool
 
       # NOTE: DataTableTool was built and placed in dsrc/include which is called by ant when compile_tab is ran


### PR DESCRIPTION
PR #414 installed `zlib1g` to fix the `libz.so.1` missing library error, but the CI is still failing with the same error.

The root cause: `DataTableTool` is a **32-bit i386 ELF binary** (`file include/DataTableTool` confirms this). `zlib1g` only installs the 64-bit version of `libz.so.1` — a 32-bit binary can't use it. The 32-bit library comes from `lib32z1`.

Replacing `zlib1g` with `lib32z1` in the workflow setup step should finally resolve the CI failures.